### PR TITLE
Suppress warning about knit engine

### DIFF
--- a/book/03-content/bibliographies-and-citations.Rmd
+++ b/book/03-content/bibliographies-and-citations.Rmd
@@ -4,7 +4,7 @@
 
 R Markdown makes it easy include citations within your document by using pandoc. For a comprehensive overview, we recommend [Section 2.8](https://bookdown.org/yihui/bookdown/citations.html) of @xie2016bookdown However, the basic usage requires us to specify a bibliography file using the `bibliography` metadata field in the YAML. For example:
 
-```{yaml, eval = FALSE}
+```yaml
 ---
 output: html_document
 bibliography: references.bib  

--- a/book/03-content/current-date.Rmd
+++ b/book/03-content/current-date.Rmd
@@ -4,7 +4,7 @@
 
 It may be useful for the date of the knitted R Markdown document to automatically update each time we rerun the file. To do this, we can add R code directly to the `date` field in the YAML, and use the `Sys.time()` function to extract the current date. As this function will by default provide the date and time, we must specify the desired date time format as shown below:
 
-```yaml
+```{cat , class.source = 'yaml'}
 ---
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
@@ -39,7 +39,7 @@ knitr::kable(formats, caption = "Date Time Formats within R")
 
 As a final note, you may even want to include some explanatory text along with the date. We can easily add any text such as "Last Compiled on" before the R code as follows:
 
-```yaml
+```{cat, class.source = 'yaml'}
 ---
 date: "Last compiled on `r format(Sys.time(), '%d %B, %Y')`"
 ---

--- a/book/03-content/current-date.Rmd
+++ b/book/03-content/current-date.Rmd
@@ -4,7 +4,7 @@
 
 It may be useful for the date of the knitted R Markdown document to automatically update each time we rerun the file. To do this, we can add R code directly to the `date` field in the YAML, and use the `Sys.time()` function to extract the current date. As this function will by default provide the date and time, we must specify the desired date time format as shown below:
 
-```{yaml, eval = FALSE}
+```yaml
 ---
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
@@ -39,7 +39,7 @@ knitr::kable(formats, caption = "Date Time Formats within R")
 
 As a final note, you may even want to include some explanatory text along with the date. We can easily add any text such as "Last Compiled on" before the R code as follows:
 
-```{yaml, eval = FALSE}
+```yaml
 ---
 date: "Last compiled on `r format(Sys.time(), '%d %B, %Y')`"
 ---

--- a/book/04-latex/latex-header-footer.Rmd
+++ b/book/04-latex/latex-header-footer.Rmd
@@ -41,7 +41,8 @@ This could be inserted in the document, or another `header.tex` file :
 
 If in an external `.tex` file, then it could be included in the header of our `rmarkdown::pdf_document` format:
 
-```{yaml, eval = FALSE}
+```yaml
+---
 title: "Document with header and footer"
 output: 
   pdf_document:

--- a/book/04-latex/latex-subfigures.Rmd
+++ b/book/04-latex/latex-subfigures.Rmd
@@ -4,13 +4,13 @@ When writing a document you may want to include some slightly more complicated f
 
 Subfigures require the LaTeX package `subfig`. We can load this via the `extra_dependencies` YAML option within the `pdf_document` output. For example:
 
-````
-```{yaml, eval = FALSE}
+```yaml
+---
 output:
-  pdf_document:
+  pBdf_document:
     extra_dependencies: subfig
+---
 ```
-````
 
 As listed within the knitr [chunk options](https://yihui.name/knitr/options/), subfigures require a few additional settings to be set in the chunk header:
 
@@ -20,7 +20,7 @@ As listed within the knitr [chunk options](https://yihui.name/knitr/options/), s
 
 An example is demonstrated below:
 
-```{yaml, eval = FALSE}
+```yaml
 ---
 output:
   pdf_document:

--- a/book/07-multiformat/custom-blocks.Rmd
+++ b/book/07-multiformat/custom-blocks.Rmd
@@ -52,7 +52,7 @@ For the HTML output, we will specify our custom class in the `style.css` file. I
 
 For the LaTeX output, we will add our custom block to the `preamble.tex` file. We will use use the **tcolorbox** LaTeX package, which offers quite a flexible set of options for creating shaded boxes, as detailed within the [package documentation](hhttp://ftp.cc.uoc.gr/mirrors/CTAN/macros/latex/contrib/tcolorbox/tcolorbox.pdf). Below, we create a new environment called `customBlock`, with a similar design of that outlined above:
 
-```{latex}
+```{cat, class.source = 'latex'}
 \usepackage[many]{tcolorbox}
 \usepackage{graphicx}
 \usetikzlibrary{calc}
@@ -120,8 +120,7 @@ If you want to have a consistent styled box but have different icons, we can glo
 
 For the PDF output, we can adapt the **tcolorbox** code shown above to add the image to the left side of the box, whereby some slight adjustments are made to offset the text from the left and to insert the image into the box. As for the HTML, if we want to create multiple custom blocks of a similar style, it is generally more useful to make a more general function which can be used to create each block. Below, we demonstrate the use of this, where a new environment `customBlockImage` is created which is then used to build our final environments that we wish to use in our report (`rmdnote`, `rmdimportant`):
 
-```{latex}
-
+```{cat, engine.opts = list(lang = 'latex')}
 % Create our general design
 \newtcolorbox{customBlockImage}[2][]{
   enhanced,
@@ -152,7 +151,6 @@ overlay={
 \newenvironment{rmdwarning}
   {\begin{customBlockImage}[colback=red]{images/important}}
   {\end{customBlockImage}}
-          
 ```
 
 Again, we have designed an output which should be consistent across HTML and PDF outputs. Below we show the output of the `rmdnote` custom block:


### PR DESCRIPTION
When building the book, there was some warnings about knitr engines that were not know and then should be set. 

This was for this code chunk 
````r
```{yaml, eval = FALSE}
some yaml code
```
````
and 
````r
```{latex, eval = FALSE}
some latex code
```
```` 

I know we can ignore the warning but was it on purpose ? 

This PR shows that in this case we could only use _pandoc highlighting_ using 
````r
```yaml
some yaml
```
````
or could use the `cat` engine that is also made for that. If a pandoc highligting language is set by `class.source` or `engine.opts` `lang` option, it is apply to the code in the rendered document. 

I let you decide if this important, and which convention we should use in the book. Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dr-harper/rmarkdown-cookbook/154)
<!-- Reviewable:end -->
