### PR TITLE
:pencil: Controlling LaTeX figure placement

### DIFF
--- a/book/04-latex/latex-figure-positioning.Rmd
+++ b/book/04-latex/latex-figure-positioning.Rmd
@@ -52,7 +52,7 @@ LaTeX’s own float placement parameters could be preventing placements that see
 
 <!--- This table may work better as a diagram? --->
 
-```{r latexFloatDefault}
+```{r latexFloatDefault, echo = FALSE}
 data.frame(
   Command = c("topfraction", "bottomfraction", "textfraction",
               "floatpagefraction", "topnumber", "bottomnumber",

--- a/book/04-latex/latex-figure-positioning.Rmd
+++ b/book/04-latex/latex-figure-positioning.Rmd
@@ -40,7 +40,7 @@ Please note, that we would strongly advise that readers consider the behaviour o
 
 An alternative to forcing all floats to be held is to force floats forwards in the text. This can remove a common issue, where a figure is shown at the top of the page on which it is created. This can break the flow of a report. We can force it so that the figure always appears after the text by using the **flafter** LaTeX package as follows:
 
-```
+```yaml
 output: 
 pdf_document:
 extra_dependencies: ["flafter"]

--- a/book/04-latex/latex-figure-positioning.Rmd
+++ b/book/04-latex/latex-figure-positioning.Rmd
@@ -23,8 +23,8 @@ Many users will initially want to prevent figures from floating in their documen
 
 ```yaml
 output: 
-pdf_document:
-extra_dependencies: ["float"]
+  pdf_document:
+    extra_dependencies: ["float"]
 ```
 
 We can use the `fig.pos` to control the float behaviour, and the use of `!H` will prevent any floating within the document. We can set the default behaviour for the document so that all chunks have this setting by including the following line at the start of your R Markdown document:
@@ -42,8 +42,8 @@ An alternative to forcing all floats to be held is to force floats forwards in t
 
 ```yaml
 output: 
-pdf_document:
-extra_dependencies: ["flafter"]
+  pdf_document:
+    extra_dependencies: ["flafter"]
 ```
 
 ### Adjust LaTeX placement rules
@@ -87,9 +87,9 @@ If we added these changes to our `premable.tex` file, we could reference to them
 
 ```yaml
 output:
-    pdf_document:
-        includes:
-            in_header: premable.tex
+  pdf_document:
+    includes:
+      in_header: premable.tex
 ```
 
 

--- a/book/04-latex/latex-figure-positioning.Rmd
+++ b/book/04-latex/latex-figure-positioning.Rmd
@@ -21,7 +21,7 @@ The default behaviour for LaTeX in R Markdown is `tbp`, that is it will try posi
 
 Many users will initially want to prevent figures from floating in their document, replicating the behaviour of a traditional word processor. To do this, we must firstly load the LaTeX package `float`. This can be done by including the following line in the YAML:
 
-```
+```yaml
 output: 
 pdf_document:
 extra_dependencies: ["float"]

--- a/book/04-latex/latex-figure-positioning.Rmd
+++ b/book/04-latex/latex-figure-positioning.Rmd
@@ -1,22 +1,96 @@
 ## Controlling the Placement of Figures
+<!--- https://stackoverflow.com/questions/16626462/figure-position-in-markdown-when-converting-to-pdf-with-knitr-and-pandoc/17648350#17648350 --->
+<!--- Some of the solutions adapted from https://texfaq.org/FAQ-floats. Link left here for future reference --->
 
-One of the common frustrations with LaTeX is how Figures and Tables are handled. Unlike in a word processor like *Microsoft Word*, LaTeX will attempt to place the figure in a position on the page which leads to the least amount of whitespace being added. In doing so, it can result in large gaps appearing between where the originally created, and where it is placed in the report.
+One of the common frustrations with LaTeX is how Figures and Tables are handled. Unlike in a word processor like *Microsoft Word*, where figures are placed directly where the user specifies, LaTeX will attempt to place the figure in a position which does not violate certain typographic rules. In doing so, it can result in figures being located away from where they are referenced in the text. This section will explain some background information on how floats work, before providing several options for how to customise their behaviour for your work.
 
-To new users of LaTeX, the behaviour of figure positioning can be fairly confusing and it is not clear how [floats]( https://en.wikibooks.org/wiki/LaTeX/Floats,_Figures_and_Captions) work. Floats are used as containers for things which cannot be broken over a page, such as tables and figures.
+### Floats
 
-You may run into some problems if you have multiple figures in rapid sucession, as this raises the problem of how they are supposed to fit on the page and still leave room for text. In this case, LaTeX stacks them all up and prints them together if possible, or leaves them to the end of the chapter in protest. The skill is to space them out within your text so that they intrude neither on the thread of your argument or discussion, nor on the visual balance of the typeset pages.
+A detailed description of floats is available within the [LaTeX Wiki](https://en.wikibooks.org/wiki/LaTeX/Floats,_Figures_and_Captions), but in summary, floats are used as containers for things which cannot be broken over a page, such as tables and figures.  By default, if the figure or table can not be contained in the space left in the current page, it is placed at the top of the next page. This behaviour can be controlled by different placement specifiers as follows:
 
-<!---
+- `h`:	Place the float here, i.e., approximately at the same point it occurs in the source text (however, not exactly at the spot)
+- `t`:	Position at the top of the page.
+- `b`:	Position at the bottom of the page.
+- `p`:	Put on a special page for floats only.
+- `!`:	Override internal parameters LaTeX uses for determining "good" float positions.
+- `H`: Places the float at precisely the location in the LaTeX code. Requires the float package (`\usepackage{float}`)
 
-### Controlling Float
+The default behaviour for LaTeX in R Markdown is `tbp`, that is it will try positioning the figure at the top of the page, then then bottom, and if not it will put them on a separate page for floats.
+
+### Preventing figures floating
+
+Many users will initially want to prevent figures from floating in their document, replicating the behaviour of a traditional word processor. To do this, we must firstly load the LaTeX package `float`. This can be done by including the following line in the YAML:
+
+```
+output: 
+pdf_document:
+extra_dependencies: ["float"]
+```
+
+We can use the `fig.pos` to control the float behaviour, and the use of `!H` will prevent any floating within the document. We can set the default behaviour for the document so that all chunks have this setting by including the following line at the start of your R Markdown document:
+
+```{r, echo=TRUE, eval=FALSE}
+knitr::opts_chunk$set(fig.pos = "!H")
+```
+
+Please note, that we would strongly advise that readers consider the behaviour of float in their document. This solution was included within the book by popular demand^[the related[StackOverflow question](https://stackoverflow.com/q/16626462/7347699) has been viewed over 40000 times] but there are some serious sides effects overriding the default settings. Primarily, you may end 
+
+### Force floats forwards
+<!--- https://tex.stackexchange.com/questions/15706/force-floats-to-be-typeset-after-their-occurrence-in-the-source-text --->
+
+An alternative to forcing all floats to be held is to force floats forwards in the text. This can remove a common issue, where a figure is shown at the top of the page on which it is created. This can break the flow of a report. We can force it so that the figure always appears after the text by using the **flafter** LaTeX package as follows:
+
+```
+output: 
+pdf_document:
+extra_dependencies: ["flafter"]
+```
+
+### Adjust LaTeX placement rules
+
+LaTeX’s own float placement parameters could be preventing placements that seem entirely “reasonable” to you — they’re notoriously rather conservative. These defaults are displayed in Table \@ref(tab:latexFloatDefault).
+
+<!--- This table may work better as a diagram? --->
+
+```{r latexFloatDefault}
+data.frame(
+  Command = c("topfraction", "bottomfraction", "textfraction",
+              "floatpagefraction", "topnumber", "bottomnumber",
+              "totalnumber"),
+  Description = c("maximum fraction of page for floats at top",
+                  "maximum fraction of page for floats at bottom",
+                  "minimum fraction of page for text",
+                  "minimum fraction of floatpage that should have floats",
+                  "maximum number of floats at top of page", "maximum number of floats at bottom of page",
+                  "maximum number of floats on a page"),
+  Default = c("0.7", "0.3", "0.2", "0.5", "2", "1", "3"),
+  stringsAsFactors=FALSE
+) %>%
+  knitr::kable(caption = "Default LaTeX float settings", escape = TRUE)
+
+```
+
+To encourage LaTeX not to move your figure, we can alter these default settings. We could include the following in our LaTeX preamble file, reducing the minimum amount of text required on a page and allow more room for floats:
+
+```latex
+\renewcommand{\topfraction}{.85}
+\renewcommand{\bottomfraction}{.7}
+\renewcommand{\textfraction}{.15}
+\renewcommand{\floatpagefraction}{.66}
+\renewcommand{\dbltopfraction}{.66}
+\renewcommand{\dblfloatpagefraction}{.66}
+\setcounter{topnumber}{9}
+\setcounter{bottomnumber}{9}
+\setcounter{totalnumber}{20}
+\setcounter{dbltopnumber}{9}
+```
+If we added these changes to our `premable.tex` file, we could reference to them within our YAML of our document:
+
+```yaml
+output:
+    pdf_document:
+        includes:
+            in_header: premable.tex
+```
 
 
-
-### Forcing the position
-
-
-
-
-### Forcing Float Forwards
-
---->

--- a/book/04-latex/latex-figure-positioning.Rmd
+++ b/book/04-latex/latex-figure-positioning.Rmd
@@ -67,7 +67,6 @@ data.frame(
   stringsAsFactors=FALSE
 ) %>%
   knitr::kable(caption = "Default LaTeX float settings", escape = TRUE)
-
 ```
 
 To encourage LaTeX not to move your figure, we can alter these default settings. We could include the following in our LaTeX preamble file, reducing the minimum amount of text required on a page and allow more room for floats:

--- a/book/04-latex/latex-figure-positioning.Rmd
+++ b/book/04-latex/latex-figure-positioning.Rmd
@@ -33,7 +33,7 @@ We can use the `fig.pos` to control the float behaviour, and the use of `!H` wil
 knitr::opts_chunk$set(fig.pos = "!H")
 ```
 
-Please note, that we would strongly advise that readers consider the behaviour of float in their document. This solution was included within the book by popular demand^[the related[StackOverflow question](https://stackoverflow.com/q/16626462/7347699) has been viewed over 40000 times] but there are some serious sides effects overriding the default settings. Primarily, you may end 
+Please note, that we would strongly advise that readers consider the behaviour of float in their document. This solution was included within the book by popular demand^[the related[StackOverflow question](https://stackoverflow.com/q/16626462/7347699) has been viewed over 40000 times] but there are some serious sides effects overriding the default settings.
 
 ### Force floats forwards
 <!--- https://tex.stackexchange.com/questions/15706/force-floats-to-be-typeset-after-their-occurrence-in-the-source-text --->


### PR DESCRIPTION
Addressing issue #49. I have rewritten this section a bit from the old content plus added new content.

I must say that I am slightly opinionated in how figure floats should be controlled. I don't think it is useful to prevent floats in LaTeX, although this is something that most new users seem to want to do!